### PR TITLE
Add required Electron install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-### Run Chrome apps in Electron.
-#### Because Google thought it would be a good idea to kill Chrome apps.
+# `electron-chrome`
+
+**Run Chrome apps in Electron.** (Because Google thought it would be a good idea to kill Chrome apps.)
 
 This is basically an incomplete polyfill on the Chrome APIs.
 
-Install:
+## Install
 ```
 git clone https://github.com/koush/electron-chrome.git
 cd electron-chrome
 npm install
 ```
 
-##### Run:
+Electron is required, and is not installed by the `npm install`. 
+Install by running `npm install -g electron` or `yarn global add electron`.
+
+## Run:
 ```
 electron --enable-logging . --app-dir=/path/to/chrome-app/
 ```
@@ -22,12 +26,12 @@ This will also download updates as they become available. For example, to run [V
 electron --enable-logging . --app-id=gidgenkbbabolejbgbpnhbimgjbffefm
 ```
 
-##### Build Installer (must be run on host platform, Mac or Windows. Linux not supported.):
+### Build Installer (must be run on host platform, Mac or Windows. Linux not supported.):
 ```
 npm run package -- --app-dir=/path/to/chrome/app/
 ```
 
-### Goals
+## Goals
 Chrome apps are being phased out on all platforms but ChromeOS.
 
 I want to continue distributing Chrome apps (Vysor) on the Chrome store (which works on ChromeOS). After the phase out, this project will allow an simple way to distribute and run Chrome apps on desktop systems. Directly from the Chrome store, including automatic updates.
@@ -35,7 +39,7 @@ I want to continue distributing Chrome apps (Vysor) on the Chrome store (which w
 Having to build and distribute a 100MB+ Electron binary per platform, per app update is not ideal. So runtime and app updates will be decoupled from the Electron update, and from each other. Ideally, the updates to Chrome apps running on electron-chrome
 are just the CRX that you get from the Chrome store, or the handful of runtime files which polyfill the chrome.* API.
 
-##### Mostly implemented:
+### Mostly implemented:
 
 chrome.identity
 
@@ -47,10 +51,10 @@ chrome.notifications
 
 chrome.app.window
 
-##### Want to implement:
+### Want to implement:
 
 chrome.usb
 
-##### Not implemented (and no plans to implement):
+### Not implemented (and no plans to implement):
 
 chrome.socket: This Chrome API is kinda crap. I ended up wrapping it with my own, and then wrapped node.js Socket as well.


### PR DESCRIPTION
This PR contains documentation changes to the README.
- Add Electron install step to README install instructions. This was brought up in #30. I had to look in the issues so see what I was missing from the installation steps / whether electron should have been installed by `npm install` step.
- Adjust headings in the README